### PR TITLE
Add unit tests for client

### DIFF
--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -1,0 +1,35 @@
+import os
+import json
+import unittest
+import tempfile
+from orangebeard.config import AutoConfig
+from orangebeard.entity.OrangebeardParameters import OrangebeardParameters
+
+class TestAutoConfig(unittest.TestCase):
+    def test_get_attributes_from_string(self):
+        attrs = AutoConfig.get_attributes_from_string('a:1;b')
+        self.assertEqual(len(attrs), 2)
+        self.assertEqual(attrs[0].key, 'a')
+        self.assertEqual(attrs[0].value, '1')
+        self.assertIsNone(attrs[1].key)
+        self.assertEqual(attrs[1].value, 'b')
+
+    def test_get_config_reads_file_and_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data = {
+                'token': 'filetoken',
+                'endpoint': 'fileend',
+                'testset': 'fileset',
+                'project': 'fileproj',
+                'description': 'desc'
+            }
+            with open(os.path.join(tmp, 'orangebeard.json'), 'w', encoding='utf-8') as f:
+                json.dump(data, f)
+            os.environ['ORANGEBEARD_TOKEN'] = 'envtoken'
+            cfg = AutoConfig.get_config(tmp)
+            self.assertEqual(cfg.token, 'envtoken')
+            self.assertEqual(cfg.endpoint, 'fileend')
+            self.assertEqual(cfg.project, 'fileproj')
+            del os.environ['ORANGEBEARD_TOKEN']
+
+# end test

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,126 @@
+import asyncio
+import uuid
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from orangebeard.OrangebeardClient import OrangebeardClient
+from orangebeard.entity.StartTestRun import StartTestRun
+from orangebeard.entity.FinishTestRun import FinishTestRun
+from orangebeard.entity.StartSuite import StartSuite
+from orangebeard.entity.StartTest import StartTest
+from orangebeard.entity.FinishTest import FinishTest
+from orangebeard.entity.StartStep import StartStep
+from orangebeard.entity.FinishStep import FinishStep
+from orangebeard.entity.Log import Log
+from orangebeard.entity.Attachment import Attachment, AttachmentFile, AttachmentMetaData
+from orangebeard.entity.TestType import TestType
+from orangebeard.entity.TestStatus import TestStatus
+from orangebeard.entity.LogFormat import LogFormat
+from orangebeard.entity.LogLevel import LogLevel
+
+class DummyResponse:
+    def __init__(self, status=200, json_data=None, text=''):
+        self.status = status
+        self._json_data = json_data
+        self._text = text
+    async def json(self):
+        return self._json_data
+    async def text(self):
+        return self._text
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class DummyClientSession:
+    def __init__(self, response=None, *args, **kwargs):
+        self._response = response or DummyResponse()
+        self.closed = False
+    def request(self, *args, **kwargs):
+        return self._response
+    async def close(self):
+        self.closed = True
+
+class TestOrangebeardClient(unittest.TestCase):
+    def setUp(self):
+        self.patcher = patch('orangebeard.OrangebeardClient.aiohttp.ClientSession', DummyClientSession)
+        self.patcher.start()
+        self.client = OrangebeardClient(endpoint='http://localhost', access_token=uuid.uuid4(), project_name='proj')
+        self.client._OrangebeardClient__client = DummyClientSession()
+
+    def tearDown(self):
+        self.patcher.stop()
+        loop = self.client._OrangebeardClient__event_loop
+        if not loop.is_closed():
+            loop.run_until_complete(self.client._OrangebeardClient__client.close())
+            loop.close()
+
+    def test_start_test_run(self):
+        actual_uuid = str(uuid.uuid4())
+        self.client._OrangebeardClient__make_api_request = AsyncMock(return_value=actual_uuid)
+        start = StartTestRun('set', datetime.now(timezone.utc), 'desc')
+        temp_uuid = self.client.start_test_run(start)
+        self.assertEqual(self.client._OrangebeardClient__uuid_mapping[temp_uuid], actual_uuid)
+        self.assertTrue(self.client._OrangebeardClient__call_events[temp_uuid].is_set())
+
+    def test_start_announced_test_run(self):
+        self.client._OrangebeardClient__make_api_request = AsyncMock(return_value=None)
+        tr_uuid = uuid.uuid4()
+        self.client.start_announced_test_run(tr_uuid)
+        self.assertEqual(self.client._OrangebeardClient__uuid_mapping[tr_uuid], tr_uuid)
+        self.assertTrue(self.client._OrangebeardClient__call_events[tr_uuid].is_set())
+
+    def test_start_suite(self):
+        self.client._OrangebeardClient__make_api_request = AsyncMock(side_effect=[str(uuid.uuid4()), [{'suiteUUID': 'real'}]])
+        start_run = StartTestRun('set', datetime.now(timezone.utc), 'desc')
+        run_uuid = self.client.start_test_run(start_run)
+        suite = StartSuite(run_uuid, ['suite'])
+        suite_temp = self.client.start_suite(suite)
+        self.assertEqual(self.client._OrangebeardClient__uuid_mapping[suite_temp[0]], 'real')
+        self.assertTrue(self.client._OrangebeardClient__call_events[suite_temp[0]].is_set())
+
+    def test_start_test_and_finish_test(self):
+        # Start run and suite first
+        self.client._OrangebeardClient__make_api_request = AsyncMock(side_effect=[str(uuid.uuid4()), [{'suiteUUID': 'real-suite'}], 'real-test', None])
+        start_run = StartTestRun('set', datetime.now(timezone.utc), 'desc')
+        run_uuid = self.client.start_test_run(start_run)
+        suite = StartSuite(run_uuid, ['suite'])
+        suite_temp = self.client.start_suite(suite)[0]
+        test = StartTest(run_uuid, suite_temp, 'tname', datetime.now(timezone.utc), TestType.TEST)
+        test_temp = self.client.start_test(test)
+        self.assertTrue(self.client._OrangebeardClient__call_events[test_temp].is_set())
+        finish = FinishTest(run_uuid, TestStatus.PASSED, datetime.now(timezone.utc))
+        self.client.finish_test(test_temp, finish)
+        loop = self.client._OrangebeardClient__event_loop
+        loop.run_until_complete(asyncio.sleep(0))
+        # ensure finish event set
+        self.assertEqual(len(self.client._OrangebeardClient__call_events), 4)
+
+    def test_start_step_and_finish_step_and_log_and_attachment(self):
+        def fake_request(method, uri, data=None, headers=None):
+            return DummyResponse(text='attach')
+        self.client._OrangebeardClient__client.request = fake_request
+        self.client._OrangebeardClient__make_api_request = AsyncMock(side_effect=[str(uuid.uuid4()), [{'suiteUUID': 'real-suite'}], 'real-test', 'real-step', 'real-log'])
+        start_run = StartTestRun('set', datetime.now(timezone.utc), 'desc')
+        run_uuid = self.client.start_test_run(start_run)
+        suite = StartSuite(run_uuid, ['suite'])
+        suite_temp = self.client.start_suite(suite)[0]
+        test = StartTest(run_uuid, suite_temp, 'tname', datetime.now(timezone.utc), TestType.TEST)
+        test_temp = self.client.start_test(test)
+        step = StartStep(run_uuid, test_temp, 'step', datetime.now(timezone.utc))
+        step_temp = self.client.start_step(step)
+        self.assertTrue(self.client._OrangebeardClient__call_events[step_temp].is_set())
+        log = Log(run_uuid, test_temp, 'msg', LogLevel.INFO, LogFormat.PLAIN_TEXT, None, datetime.now(timezone.utc))
+        log_temp = self.client.log(log)
+        self.client._OrangebeardClient__event_loop.run_until_complete(asyncio.sleep(0))
+        self.assertEqual(self.client._OrangebeardClient__uuid_mapping[log_temp], 'real-log')
+        meta = AttachmentMetaData(run_uuid, test_temp, log_temp)
+        attach = Attachment(AttachmentFile('f.txt', b'data'), meta)
+        self.client.send_attachment(attach)
+        self.client._OrangebeardClient__event_loop.run_until_complete(asyncio.sleep(0))
+        # after attachment event set
+        self.assertTrue(any(ev.is_set() for ev in self.client._OrangebeardClient__call_events.values()))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_make_api_request.py
+++ b/tests/test_make_api_request.py
@@ -1,0 +1,64 @@
+import asyncio
+import uuid
+import unittest
+from unittest.mock import AsyncMock, patch
+from aiohttp import ClientError, ContentTypeError
+
+from orangebeard.OrangebeardClient import OrangebeardClient
+
+class DummyResponse:
+    def __init__(self, json_data=None):
+        self._json_data = json_data
+        self.status = 200
+    async def json(self):
+        if isinstance(self._json_data, Exception):
+            raise self._json_data
+        return self._json_data
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class DummyClientSession:
+    def __init__(self, responses):
+        self.responses = responses
+    def request(self, *args, **kwargs):
+        resp = self.responses.pop(0)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+    async def close(self):
+        pass
+
+class TestMakeApiRequest(unittest.IsolatedAsyncioTestCase):
+    async def test_success(self):
+        with patch('orangebeard.OrangebeardClient.aiohttp.ClientSession', lambda *a, **k: DummyClientSession([DummyResponse({'a':1})])):
+            client = OrangebeardClient(endpoint='http://x', access_token=uuid.uuid4(), project_name='p')
+            client._OrangebeardClient__client = DummyClientSession([DummyResponse({'a': 1})])
+            result = await client._OrangebeardClient__make_api_request('GET', '/u')
+            self.assertEqual(result, {'a': 1})
+
+    async def test_content_type_error(self):
+        with patch('orangebeard.OrangebeardClient.aiohttp.ClientSession', lambda *a, **k: DummyClientSession([DummyResponse(ContentTypeError(None, None))])):
+            client = OrangebeardClient(endpoint='http://x', access_token=uuid.uuid4(), project_name='p')
+            client._OrangebeardClient__client = DummyClientSession([DummyResponse(ContentTypeError(None, None))])
+            result = await client._OrangebeardClient__make_api_request('GET', '/u')
+            self.assertIsNone(result)
+
+    async def test_retries_and_failure(self):
+        with patch('orangebeard.OrangebeardClient.aiohttp.ClientSession', lambda *a, **k: DummyClientSession([ClientError(), ClientError()])):
+            client = OrangebeardClient(endpoint='http://x', access_token=uuid.uuid4(), project_name='p')
+            client._OrangebeardClient__client = DummyClientSession([ClientError(), ClientError()])
+            async def sleep(_):
+                return None
+            asyncio_sleep = asyncio.sleep
+            asyncio.sleep = sleep
+            try:
+                with self.assertRaises(ConnectionError):
+                    await client._OrangebeardClient__make_api_request('GET', '/u', retry_count=2)
+                self.assertFalse(client._OrangebeardClient__connection_with_orangebeard_is_valid)
+            finally:
+                asyncio.sleep = asyncio_sleep
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -1,0 +1,21 @@
+import unittest
+from orangebeard.entity.Serializable import Serializable
+
+class Dummy(Serializable):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+class TestSerializable(unittest.TestCase):
+    def test_getitem_and_to_json(self):
+        d = Dummy(1, 'two')
+        self.assertEqual(d['a'], 1)
+        self.assertEqual(d['b'], 'two')
+        with self.assertRaises(KeyError):
+            _ = d['missing']
+        json_str = d.to_json()
+        self.assertIn('"a": 1', json_str)
+        self.assertIn('"b": "two"', json_str)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add sample unit tests for Serializable and configuration helpers
- test OrangebeardClient behaviour by mocking network access
- add tests for low level API request helper

## Testing
- `python -m unittest discover -v`