### PR TITLE
Add tests for AutoConfig

### DIFF
--- a/orangebeard/config/AutoConfig.py
+++ b/orangebeard/config/AutoConfig.py
@@ -18,8 +18,8 @@ def update_config_parameters_from_env(current_config: OrangebeardParameters) -> 
     current_config.project = os.environ.get('ORANGEBEARD_PROJECT', current_config.project)
     current_config.description = os.environ.get('ORANGEBEARD_DESCRIPTION', current_config.description)
     current_config.attributes = get_attributes_from_string(
-        os.environ.get('ORANGEBEARD_ENDPOINT', '')) if os.environ.get(
-        'ORANGEBEARD_ENDPOINT') else current_config.attributes
+        os.environ.get('ORANGEBEARD_ATTRIBUTES', '')) if os.environ.get(
+        'ORANGEBEARD_ATTRIBUTES') else current_config.attributes
     current_config.ref_url = os.environ.get('ORANGEBEARD_REF_URL', current_config.ref_url)
 
     return current_config

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -1,0 +1,25 @@
+import os
+from orangebeard.entity.Attribute import Attribute
+from orangebeard.entity.OrangebeardParameters import OrangebeardParameters
+from orangebeard.config.AutoConfig import get_attributes_from_string, update_config_parameters_from_env
+
+def test_get_attributes_from_string():
+    attrs = get_attributes_from_string("key1:val1;tag2")
+    assert len(attrs) == 2
+    assert isinstance(attrs[0], Attribute)
+    assert attrs[0].key == "key1"
+    assert attrs[0].value == "val1"
+    assert attrs[1].key is None
+    assert attrs[1].value == "tag2"
+
+
+def test_update_config_parameters_from_env_reads_attributes(monkeypatch):
+    monkeypatch.setenv("ORANGEBEARD_ATTRIBUTES", "key1:val1;tag2")
+    params = OrangebeardParameters(attributes=None)
+    updated = update_config_parameters_from_env(params)
+    assert updated.attributes is not None
+    assert len(updated.attributes) == 2
+    assert updated.attributes[0].key == "key1"
+    assert updated.attributes[0].value == "val1"
+    assert updated.attributes[1].key is None
+    assert updated.attributes[1].value == "tag2"


### PR DESCRIPTION
## Summary
- ensure update_config_parameters_from_env uses `ORANGEBEARD_ATTRIBUTES`
- test attribute string parser

## Testing
- `pytest -q` *(fails: command not found)*